### PR TITLE
Adding aliases for gridss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.0.1] - 2023-01-09
+- Added new gridss aliases (gridss_matched and gridss_matched_by_tumor_group)
+
 ## [1.0.0] - 2022-12-13
 - modified README.md
 - added parameter blacklist
@@ -28,4 +32,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - renamed vidarrtest-regression.json to vidarrtest-regression.json.in
 
-[Unreleased]:

--- a/vidarrbuild.json
+++ b/vidarrbuild.json
@@ -1,6 +1,8 @@
 {
     "names": [
-        "gridss"
+        "gridss",
+        "gridss_matched_by_tumor_group",
+        "gridss_matched"
     ],
     "wdl": "gridss.wdl"
 }


### PR DESCRIPTION
This is a really small update, adding aliases for gridss for the sake of clarity (similar to what we have for delly)